### PR TITLE
Use ldap_tls_cacertdir rather than ldap_tls_cacert

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Attributes
 | ['ldap_group_object_class'] | 'posixGroup' | |
 | ['ldap_id_use_start_tls'] | 'true' | |
 | ['ldap_tls_reqcert'] | 'never' | |
-| ['ldap_tls_cacertdir'] | '/etc/pki/tls/certs' | |
+| ['ldap_tls_cacert'] | '/etc/pki/tls/certs/ca-bundle.crt' or '/etc/ssl/certs/ca-certificates.crt' | defaults for RHEL and others respectively |
 | ['ldap_default_bind_dn'] | 'cn=bindaccount,dc=yourcompany,dc=com' | if you have a domain that doesn't require binding set this attributes to nil
 | ['ldap_default_authtok'] | 'bind_password' | if you have a domain that doesn't require binding set this to nil | 
 | ['authconfig_params'] | '--enablesssd --enablesssdauth --enablelocauthorize --update' | |
@@ -53,6 +53,22 @@ Recipes
 -------
 
 *default: Installs and configures sssd daemon
+
+CA Certificates
+---------------
+
+If you manage your own CA then the easiest way to inject the certificate for system-wide use is as follows:
+
+### RHEL
+
+    cp ca.crt /etc/pki/ca-trust/source/anchors
+    update-ca-trust enable
+    update-ca-trust extract
+
+### Debian
+
+    cp ca.crt /usr/local/share/ca-certificates
+    update-ca-certificates
 
 License and Author
 ------------------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -38,7 +38,7 @@ default['sssd_ldap']['ldap_group_object_class'] = 'posixGroup'
 
 default['sssd_ldap']['ldap_id_use_start_tls'] = 'true'
 default['sssd_ldap']['ldap_tls_reqcert'] = 'never'
-default['sssd_ldap']['ldap_tls_cacertdir'] = '/etc/pki/tls/certs'
+default['sssd_ldap']['ldap_tls_cacert'] = value_for_platform_family('rhel' => '/etc/pki/tls/certs/ca-bundle.crt', 'default' => '/etc/ssl/certs/ca-certificates.crt')
 
 # if you have a domain that doesn't require binding set these two attributes to nil
 default['sssd_ldap']['ldap_default_bind_dn'] = 'cn=bindaccount,dc=yourcompany,dc=com'

--- a/templates/default/sssd.conf.erb
+++ b/templates/default/sssd.conf.erb
@@ -20,7 +20,7 @@ ldap_schema = <%= node['sssd_ldap']['ldap_schema'] %>
 ldap_uri = <%= node['sssd_ldap']['ldap_uri'] %>
 
 ldap_tls_reqcert = <%= node['sssd_ldap']['ldap_tls_reqcert'] %>
-ldap_tls_cacertdir = <%= node['sssd_ldap']['ldap_tls_cacertdir'] %>
+ldap_tls_cacert = <%= node['sssd_ldap']['ldap_tls_cacert'] %>
 ldap_id_use_start_tls = <%= node['sssd_ldap']['ldap_id_use_start_tls'] %>
 
 ldap_search_base = <%= node['sssd_ldap']['ldap_search_base'] %>


### PR DESCRIPTION
ldap_tls_cacertdir expects a directory containing individual
certificate files ending in .0. RHEL does not install these and yet
the default attribute value was specific to RHEL. It is least
confusing to use ldap_tls_cacert on all systems and point it at the
bundle file. Both RHEL and Debian include utilities to manage this
file.
