### PR TITLE
Fix sssd installtion on SLES 15 SP2 and higher

### DIFF
--- a/.delivery/project.toml
+++ b/.delivery/project.toml
@@ -1,9 +1,0 @@
-[local_phases]
-unit = "rspec spec/"
-lint = 'cookstyle --display-cop-names --extra-details'
-syntax = "echo skipping"
-provision = "echo skipping"
-deploy = "echo skipping"
-smoke = "echo skipping"
-functional = "echo skipping"
-cleanup = "echo skipping"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,34 +8,11 @@ name: ci
       - main
 
 jobs:
-  delivery:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run Chef Delivery
-        uses: actionshub/chef-delivery@main
-        env:
-          CHEF_LICENSE: accept-no-persist
-
-  yamllint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run yaml Lint
-        uses: actionshub/yamllint@main
-
-  mdl:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run Markdown Lint
-        uses: actionshub/markdownlint@main
+  lint-unit:
+    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@0.0.3
 
   integration:
-    needs: [mdl, yamllint, delivery]
+    needs: lint-unit
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,15 @@ jobs:
     strategy:
       matrix:
         os:
+          - almalinux-8
           - amazonlinux-2
           - centos-7
-          - centos-8
-          - debian-9
+          - centos-stream-8
           - debian-10
+          - debian-11
           - fedora-latest
           - opensuse-leap-15
+          - rockylinux-8
           - ubuntu-1804
           - ubuntu-2004
         suite:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of sssd_ldap.
 
 ## Unreleased
 
+- Add sssd-ldap package installation for Suse distros
+
 ## 5.1.2 - *2021-08-31*
 
 - Standardise files with files in sous-chefs/repo-management

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file is used to list changes made in each version of sssd_ldap.
 ## Unreleased
 
 - Add sssd-ldap package installation for Suse distros
+- Remove delivery and move to calling RSpec directly via a reusable workflow
 
 ## 5.1.2 - *2021-08-31*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is used to list changes made in each version of sssd_ldap.
 
 - Add sssd-ldap package installation for Suse distros
 - Remove delivery and move to calling RSpec directly via a reusable workflow
+- Update tested platforms
 
 ## 5.1.2 - *2021-08-31*
 

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -32,9 +32,9 @@ platforms:
       image: dokken/debian-10
       pid_one_command: /bin/systemd
 
-  - name: debian-9
+  - name: debian-11
     driver:
-      image: dokken/debian-9
+      image: dokken/debian-11
       pid_one_command: /bin/systemd
 
   - name: centos-7

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -10,39 +10,41 @@ transport:
 
 provisioner:
   name: dokken
-  deprecations_as_errors: true
 
 verifier:
   name: inspec
 
 platforms:
+  - name: almalinux-8
+    driver:
+      image: dokken/almalinux-8
+      pid_one_command: /usr/lib/systemd/systemd
+      internediate_instructions:
+        - RUN touch /etc/fstab
+
   - name: amazonlinux-2
     driver:
       image: dokken/amazonlinux-2
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: debian-9
-    driver:
-      image: dokken/debian-9
-      pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
-
   - name: debian-10
     driver:
       image: dokken/debian-10
       pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
+
+  - name: debian-9
+    driver:
+      image: dokken/debian-9
+      pid_one_command: /bin/systemd
 
   - name: centos-7
     driver:
       image: dokken/centos-7
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: centos-8
+  - name: centos-stream-8
     driver:
-      image: dokken/centos-8
+      image: dokken/centos-stream-8
       pid_one_command: /usr/lib/systemd/systemd
       internediate_instructions:
         - RUN touch /etc/fstab
@@ -56,17 +58,20 @@ platforms:
     driver:
       image: dokken/ubuntu-18.04
       pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
 
   - name: ubuntu-20.04
     driver:
       image: dokken/ubuntu-20.04
       pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
 
   - name: opensuse-leap-15
     driver:
       image: dokken/opensuse-leap-15
-      pid_one_command: /bin/systemd
+      pid_one_command: /usr/lib/systemd/systemd
+
+  - name: rockylinux-8
+    driver:
+      image: dokken/rockylinux-8
+      pid_one_command: /usr/lib/systemd/systemd
+      internediate_instructions:
+        - RUN touch /etc/fstab

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -2,7 +2,7 @@ driver:
   name: vagrant
 
 provisioner:
-  name: chef_zero
+  name: chef_infra
   deprecations_as_errors: true
   chef_license: accept-no-persist
 
@@ -11,13 +11,15 @@ verifier:
 
 platforms:
 
+  - name: almalinux-8
   - name: amazonlinux-2
   - name: centos-7
-  - name: centos-8
-  - name: debian-9
+  - name: centos-stream-8
   - name: debian-10
+  - name: debian-11
   - name: fedora-latest
   - name: opensuse-leap-15
+  - name: rockylinux-8
   - name: ubuntu-18.04
   - name: ubuntu-20.04
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -30,6 +30,11 @@ package 'sssd' do
   action :install
 end
 
+package 'sssd-ldap' do
+  action :install
+  only_if { platform_family?('suse') }
+end
+
 package 'libsss-sudo' do
   action :install
   only_if { platform_family?('debian') && node['sssd_ldap']['ldap_sudo'] }


### PR DESCRIPTION
# Description

I've been using this cookbook with SLES 12 and 15 without any issues until SP2 for SLES 15 was released. Starting with this release, sssd-ldap package is optional, so it's not installed by default with sssd and as a result, sssd fails to start. Manual installation of sssd-ldap with subsequent sssd restart fixes this problem, so this PR just adds sssd-ldap installation as an additional step for Suse distros family.

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
