### PR TITLE
Updated sssd.conf to be sensitive by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of sssd_ldap.
 
 ## Unreleased
 
+Updated sssd.conf template to be sensitive by default
+
 ## 5.2.6 - *2023-10-31*
 
 ## 5.2.5 - *2023-09-28*

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-default['sssd_ldap']['sssd_conf_sensitive'] = false
+default['sssd_ldap']['sssd_conf_sensitive'] = true
 default['sssd_ldap']['filter_users'] = %w(root named avahi haldaemon dbus radiusd news nscd)
 default['sssd_ldap']['filter_groups'] = []
 default['sssd_ldap']['sssd_conf']['id_provider'] = 'ldap'


### PR DESCRIPTION
# Description

This PR updates the `sssd.conf` template to be sensitive by default. Since this file can contain secrets, I believe that it is best for it to be sensitive by default (unless the user explicitly requests it not to be) so that the default option is the secure option. It may be feasible to have a mechanism where the template is only marked sensitive if any sensitive keys are set in `node['sssd_ldap']['sssd_conf']`, but I wasn't sure how to best approach that so I thought this would be a good step for the moment.

## Issues Resolved

https://github.com/sous-chefs/sssd_ldap/issues/65

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
